### PR TITLE
Rewrite connection logic - Fixes #9

### DIFF
--- a/dev/src/MCUtil.ts
+++ b/dev/src/MCUtil.ts
@@ -11,6 +11,7 @@
 
 import { Uri } from "vscode";
 import * as path from "path";
+import Log from "./Logger";
 // import { Log } from "./Logger";
 
 /**
@@ -101,7 +102,7 @@ export function buildMCUrl(connInfo: IConnectionInfo): Uri {
  * Convert a URI to a ConnectionInfo (for saving to Settings).
  * A URI type with a 'port' field would be preferable, but vscode does not have this.
  */
-export function getConnInfoFrom(url: Uri): IConnectionInfo | undefined {
+export function getConnInfoFrom(url: Uri): IConnectionInfo {
     const colonIndex: number = url.authority.indexOf(":");      // non-nls
 
     const host = url.authority.substring(0, colonIndex);
@@ -109,7 +110,7 @@ export function getConnInfoFrom(url: Uri): IConnectionInfo | undefined {
 
     const port: number = Number(portStr);
     if (!isGoodPort(port)) {
-        return undefined;
+        Log.e(`Bad port ${portStr} passed to getConnInfoFrom`);
     }
     // Log.i(`Loaded connection info host ${host} port ${port}`);
 

--- a/dev/src/command/NewConnectionCmd.ts
+++ b/dev/src/command/NewConnectionCmd.ts
@@ -10,38 +10,48 @@
  *******************************************************************************/
 
 import * as vscode from "vscode";
-import * as request from "request-promise-native";
-import * as reqErrors from "request-promise-native/errors";
 
 import * as MCUtil from "../MCUtil";
 import ConnectionManager from "../microclimate/connection/ConnectionManager";
-import Endpoints from "../constants/Endpoints";
 import Log from "../Logger";
 import Commands from "../constants/Commands";
 import Connection from "../microclimate/connection/Connection";
 import Translator from "../constants/strings/translator";
 import StringNamespaces from "../constants/strings/StringNamespaces";
+import MCEnvironment from "../microclimate/connection/MCEnvironment";
 
 export const DEFAULT_CONNINFO: MCUtil.IConnectionInfo = {
     host: "localhost",      // non-nls
     port: 9090
 };
 
-// From https://github.ibm.com/dev-ex/microclimate/blob/master/docker/portal/server.js#L229
-interface IMicroclimateEnvData {
-    devops_available: boolean;
-    editor_url: string;
-    microclimate_version: string;
-    running_on_icp: boolean;
-    socket_namespace?: string;
-    user_string?: string;
-    workspace_location: string;
-}
-
 const STRING_NS = StringNamespaces.CMD_NEW_CONNECTION;
 
-export async function newConnectionCmd(): Promise<void> {
+export async function newConnectionCmd(connInfo?: MCUtil.IConnectionInfo): Promise<Connection | undefined> {
     Log.d("New connection command invoked");
+
+    if (connInfo == null) {
+        // Get it from the user
+        connInfo = await getConnectInfo();
+        if (connInfo == null) {
+            Log.d("User cancelled entering connect info");
+            // If the user didn't enter anything valid, exit here
+            return undefined;
+        }
+    }
+
+    const connection = await tryAddConnection(connInfo);
+    if (connection == null) {
+        // user gave up
+        return undefined;
+    }
+
+    await offerToOpenWorkspace(connection);
+    return connection;
+}
+
+async function getConnectInfo(): Promise<MCUtil.IConnectionInfo | undefined> {
+    Log.d("Prompting for connect info");
 
     // Only localhost is permitted. Uncomment this to (start to) support other hosts
     /*
@@ -56,7 +66,7 @@ export async function newConnectionCmd(): Promise<void> {
         return;
     }*/
 
-    const hostname = DEFAULT_CONNINFO.host;
+    const host = DEFAULT_CONNINFO.host;
 
     let tryAgain = true;
     let port: number | undefined;
@@ -84,167 +94,106 @@ export async function newConnectionCmd(): Promise<void> {
         }
     }
 
-    if (hostname != null && port != null) {
-        const connInfo: MCUtil.IConnectionInfo = {
-            host: hostname,
-            port: port
-        };
-        return tryAddConnection(connInfo);
+    if (host == null || port == null) {
+        // user never entered anything valid
+        return undefined;
+    }
+
+    return { host, port };
+}
+
+async function offerToOpenWorkspace(connection: Connection): Promise<void> {
+    let inMcWorkspace = false;
+    // See if the user has this connection's workspace open
+    const wsFolders = vscode.workspace.workspaceFolders;
+    if (wsFolders != null) {
+        inMcWorkspace = wsFolders.some( (folder) => folder.uri.fsPath.includes(connection.workspacePath.fsPath));
+    }
+
+    const successMsg = Translator.t(STRING_NS, "connectionSucceeded",
+            { connectionUri: connection.mcUri, workspacePath: connection.workspacePath.fsPath }
+    );
+    Log.i(successMsg);
+
+    if (!inMcWorkspace) {
+        const openWsBtn = Translator.t(STRING_NS, "openWorkspaceBtn");
+
+        // Provide a button to change their workspace to the microclimate-workspace if they wish
+        vscode.window.showInformationMessage(successMsg, openWsBtn)
+            .then ( (response) => {
+                if (response === openWsBtn) {
+                    vscode.commands.executeCommand(Commands.VSC_OPEN_FOLDER, connection.workspacePath);
+                }
+            });
+    }
+    else {
+        // The user already has the workspace open, we don't have to do it for them.
+        vscode.window.showInformationMessage(successMsg);
     }
 }
 
 /**
  * Test connecting to the given host:port.
+ *
  * If it fails, display a message to the user and allow them to either try to connect again with the same info,
  * or start the 'wizard' from the beginning to enter a new host/port.
+ *
+ * @returns The new Connection if we formed one, or undefined if we didn't.
  */
-export async function tryAddConnection(connInfo: MCUtil.IConnectionInfo): Promise<void> {
+export async function tryAddConnection(connInfo: MCUtil.IConnectionInfo): Promise<Connection | undefined> {
 
     Log.i("TryAddConnection", connInfo);
 
-    return new Promise<void>( (resolve) => {
-        testConnection(connInfo)
-            .then(async (connection: Connection) => {
-                Log.d("TestConnection success to " + connection.mcUri);
-                // Connection succeeded, let the user know.
-                // The ConnectionManager will signal the change and the UI will update accordingly.
+    try {
+        const uri = MCUtil.buildMCUrl(connInfo);
+        const microclimateData = await MCEnvironment.getEnvData(uri);
+        // Connected successfully, now validate it's a good instance
+        return await onSuccessfulConnection(uri, connInfo.host, microclimateData);
+    }
+    catch (err) {
+        const errMsg = err.message || err.toString();
+        Log.w("Connection test failed: " + errMsg);
 
-                // Check if the user has this connection's workspace folder opened.
-                let inMcWorkspace = false;
-                const wsFolders = vscode.workspace.workspaceFolders;
-                if (wsFolders != null) {
-                    inMcWorkspace = wsFolders.find( (folder) => folder.uri.fsPath.includes(connection.workspacePath.fsPath)) != null;
-                }
-
-                const successMsg = Translator.t(STRING_NS, "connectionSucceeded",
-                        { connectionUri: connection.mcUri, workspacePath: connection.workspacePath.fsPath }
-                );
-                Log.d(successMsg);
-
-                if (!inMcWorkspace) {
-                    const openWsBtn = Translator.t(STRING_NS, "openWorkspaceBtn");
-
-                    // Provide a button to change their workspace to the microclimate-workspace if they wish
-                    vscode.window.showInformationMessage(successMsg, openWsBtn)    // non-nls
-                        .then ( (response) => {
-                            if (response === openWsBtn) {
-                                vscode.commands.executeCommand(Commands.VSC_OPEN_FOLDER, connection.workspacePath);
-                            }
-                        });
-                }
-                else {
-                    // The user already has the workspace open, we don't have to do it for them.
-                    vscode.window.showInformationMessage(successMsg);
-                }
-
-                return resolve();
-            })
-            .catch(async (s: any) => {
-                Log.w("Connection test failed with message " + s);
-
-                const editBtn  = Translator.t(STRING_NS, "editConnectionBtn");
-                const retryBtn  = Translator.t(STRING_NS, "retryConnectionBtn");
-                const response = await vscode.window.showErrorMessage(s, editBtn, retryBtn);
-                if (response === editBtn) {
-                    // start again from the beginning
-                    return newConnectionCmd();
-                }
-                else if (response === retryBtn) {
-                    // try to connect with the same host:port
-                    return tryAddConnection(connInfo);
-                }
-            });
-    });
+        const editBtn  = Translator.t(STRING_NS, "editConnectionBtn");
+        const retryBtn  = Translator.t(STRING_NS, "retryConnectionBtn");
+        const response = await vscode.window.showErrorMessage(errMsg, editBtn, retryBtn);
+        if (response === editBtn) {
+            // start again from the beginning (and this command instance will terminate after this function call exits)
+            newConnectionCmd();
+            return undefined;
+        }
+        else if (response === retryBtn) {
+            // try to connect with the same host:port
+            return await tryAddConnection(connInfo);
+        }
+        return undefined;
+    }
 }
-
-// Return value resolves to a user-friendly message or error, ie "connection to $url succeeded"
-async function testConnection(connInfo: MCUtil.IConnectionInfo): Promise<Connection> {
-
-    const uri = MCUtil.buildMCUrl(connInfo);
-    const envUri: vscode.Uri = uri.with({ path: Endpoints.ENVIRONMENT });
-
-    const connectTimeout = 2500;
-
-    return new Promise<Connection>( (resolve, reject) => {
-        request.get(envUri.toString(), { json: true, timeout: connectTimeout })
-            .then( (microclimateData: IMicroclimateEnvData) => {
-                // Connected successfully
-                return resolve(onSuccessfulConnection(uri, connInfo.host, microclimateData));
-            })
-            .catch( (err: any) => {
-                Log.i(`Request fail - ${err}`);
-                if (err instanceof reqErrors.RequestError) {
-                    return reject(Translator.t(STRING_NS, "connectFailed", { uri: uri }));
-                }
-
-                return reject(err.toString());
-            });
-    });
-}
-
-// microclimate_version and workspace_location were both added in Microclimate 18.09
-// Portal Restart API improvement was added in 18.11
-const requiredVersion: number = 1812;
-const requiredVersionStr: string = "18.12";     // non-nls
-const internalBuildRx: RegExp = /^\d{4}_M\d+_[EI]/;
 
 /**
  * We've determined by this point that Microclimate is running at the given URI,
  * but we have to validate now that it's a new enough version.
  */
-async function onSuccessfulConnection(mcUri: vscode.Uri, host: string, mcEnvData: IMicroclimateEnvData): Promise<Connection> {
+export async function onSuccessfulConnection(mcUri: vscode.Uri, host: string, mcEnvData: MCEnvironment.IMCEnvData): Promise<Connection> {
+    Log.i("Microclimate ENV data:", mcEnvData);
 
-    return new Promise<Connection>( (resolve, reject) => {
-        Log.i("Microclimate ENV data:", mcEnvData);
+    const rawVersion: string = mcEnvData.microclimate_version;
+    const rawWorkspace: string = mcEnvData.workspace_location;
 
-        if (mcEnvData == null) {
-            Log.e("Null microclimateData passed to onSuccessfulConnection");
-            // fail with a generic message because this should never happen
-            reject(Translator.t(STRING_NS, "connectFailed", { uri: mcUri }));
-        }
+    Log.d("rawVersion from Microclimate is", rawVersion);
+    Log.d("rawWorkspace from Microclimate is", rawWorkspace);
+    if (rawVersion == null || rawWorkspace == null) {
+        Log.e("Microclimate environment did not provide either version or workspace. Data provided is:", mcEnvData);
+        throw new Error(Translator.t(STRING_NS, "versionNotProvided", { requiredVersion: MCEnvironment.REQUIRED_VERSION_STR }));
+    }
 
-        const rawVersion: string = mcEnvData.microclimate_version;
-        const rawWorkspace: string = mcEnvData.workspace_location;
+    const versionNum = MCEnvironment.getVersionNumber(mcEnvData);
 
-        Log.d("rawVersion from Microclimate is", rawVersion);
-        Log.d("rawWorkspace from Microclimate is", rawWorkspace);
-        if (rawVersion == null || rawWorkspace == null) {
-            Log.e("Microclimate environment did not provide either version or workspace. Data provided is:", mcEnvData);
-            return reject(Translator.t(STRING_NS, "versionNotProvided", { requiredVersion: requiredVersionStr }));
-        }
-
-        let versionNum: number;
-        if (rawVersion === "latest") {      // non-nls
-            // This means it's being hosted by an internal MC dev.
-            // There's nothing we can do here but assume they have all the features we need.
-            Log.i("Dev version of Microclimate");
-            versionNum = Number.MAX_SAFE_INTEGER;
-        }
-        else if (rawVersion.match(internalBuildRx) != null) {
-            Log.i("Internal build of Microclimate");
-            versionNum = Number.MAX_SAFE_INTEGER;
-        }
-        else {
-            versionNum = Number(rawVersion);
-            if (isNaN(versionNum)) {
-                Log.e("Couldn't convert provided version to Number, version is: " + rawVersion);
-                return reject(Translator.t(STRING_NS, "versionNotRecognized", { rawVersion: rawVersion, requiredVersion: requiredVersionStr}));
-            }
-            else if (versionNum < requiredVersion) {
-                Log.e(`Microclimate version ${versionNum} is too old.`);
-                return reject(Translator.t(STRING_NS, "versionTooOld", { rawVersion: rawVersion, requiredVersion: requiredVersionStr}));
-            }
-        }
-
-        const workspaceUri: vscode.Uri = vscode.Uri.file(rawWorkspace);
-
-        ConnectionManager.instance.addConnection(mcUri, host, versionNum, workspaceUri)
-            .then( (newConnection: Connection) => {
-                return resolve(newConnection);
-            })
-            .catch((err: string) => {
-                Log.i("New connection rejected by ConnectionManager ", err);
-                return reject(err);
-            });
-    });
+    try {
+        return await ConnectionManager.instance.addConnection(mcUri, host, versionNum, rawWorkspace);
+    }
+    catch (err) {
+        Log.i("New connection rejected by ConnectionManager ", err.message || err);
+        throw err;
+    }
 }

--- a/dev/src/constants/strings/strings-en.json
+++ b/dev/src/constants/strings/strings-en.json
@@ -2,6 +2,8 @@
     "microclimateName": "Microclimate",
     "activeMsg": "Microclimate Tools for VSCode are active!",
     "connectionAlreadyExists": "Connection already exists at {{- uri }}.",
+    "failedToReconnect": "Couldn't reconnect to Microclimate at {{- uri }}, please try re-creating the connection.",
+    "versionChanged": "Microclimate at {{- uri }} was previously version {{ oldVersion }}, but is now {{ newVersion }}.",
     "errorSavingConnections": "Error saving connections: {{- err }}.",
 
     "statesSeparator": " or ",

--- a/dev/src/microclimate/connection/ConnectionManager.ts
+++ b/dev/src/microclimate/connection/ConnectionManager.ts
@@ -13,11 +13,12 @@ import * as vscode from "vscode";
 
 import * as MCUtil from "../../MCUtil";
 import Connection from "./Connection";
-import { tryAddConnection } from "../../command/NewConnectionCmd";
+import { tryAddConnection, newConnectionCmd } from "../../command/NewConnectionCmd";
 import Log from "../../Logger";
 import Settings from "../../constants/Settings";
 import Translator from "../../constants/strings/translator";
 import StringNamespaces from "../../constants/strings/StringNamespaces";
+import MCEnvironment from "./MCEnvironment";
 
 export default class ConnectionManager {
 
@@ -31,7 +32,9 @@ export default class ConnectionManager {
     ) {
         const connectionInfos: MCUtil.IConnectionInfo[] = ConnectionManager.loadConnections();
         Log.i(`Loaded ${connectionInfos.length} connections from settings`);
-        connectionInfos.forEach((connInfo) =>
+        connectionInfos.forEach( (connInfo) =>
+            // Note this is done async
+            // We use tryAddConnection over newConnectionCmd because it succeeds silently (but still reports failure)
             tryAddConnection(connInfo)
         );
     }
@@ -44,22 +47,22 @@ export default class ConnectionManager {
         return this._connections;
     }
 
-    public async addConnection(uri: vscode.Uri, host: string, mcVersion: number, workspace: vscode.Uri): Promise<Connection> {
-        return new Promise<Connection>( (resolve, reject) => {
-            if (this.connectionExists(uri)) {
-                return reject(Translator.t(StringNamespaces.DEFAULT, "connectionAlreadyExists", { uri }));
-            }
+    public async addConnection(uri: vscode.Uri, host: string, mcVersion: number, workspace: string): Promise<Connection> {
+        if (this.connectionExists(uri)) {
+            const alreadyExists = Translator.t(StringNamespaces.DEFAULT, "connectionAlreadyExists", { uri });
+            // Log.i(alreadyExists);
+            throw new Error(alreadyExists);
+        }
 
-            // all validation that this connection is good must be done by this point
+        // all validation that this connection is good must be done by this point
 
-            const newConnection: Connection = new Connection(uri, host, mcVersion, workspace);
-            Log.i("New Connection @ " + uri);
-            this._connections.push(newConnection);
-            ConnectionManager.saveConnections();
+        const newConnection: Connection = new Connection(uri, host, mcVersion, workspace);
+        Log.i("New Connection @ " + uri);
+        this._connections.push(newConnection);
+        ConnectionManager.saveConnections();
 
-            this.onChange();
-            return resolve(newConnection);
-        });
+        this.onChange();
+        return newConnection;
     }
 
     public async removeConnection(connection: Connection): Promise<boolean> {
@@ -74,6 +77,63 @@ export default class ConnectionManager {
         ConnectionManager.saveConnections();
         this.onChange();
         return true;
+    }
+
+    /**
+     * To be called on connection reconnect. Hits the environment endpoint at the given existing Connection's URI,
+     * and returns if the response data matches the existing Connection.
+     *
+     * The given Connection will be destroyed if the data does not match (ie, this function returns `false`),
+     * and thus must not do anything further.
+     */
+    public async verifyReconnect(connection: Connection): Promise<boolean> {
+        Log.d("Verifying reconnect at " + connection.mcUri);
+
+        let tries = 0;
+        let newEnvData: MCEnvironment.IMCEnvData | undefined;
+        // Sometimes this can execute before Portal is ready, resulting in a 404.
+        while (newEnvData == null && tries < 10) {
+            tries++;
+            try {
+                newEnvData = await MCEnvironment.getEnvData(connection.mcUri);
+            }
+            catch (err) {
+                // wait briefly before trying again
+                await new Promise( (resolve) => setTimeout(resolve, 250));
+            }
+        }
+
+        if (newEnvData == null) {
+            // I don't think this will ever happen
+            Log.e("Couldn't get a good response from environment endpoint " + connection.mcUri);
+            vscode.window.showErrorMessage(Translator.t(StringNamespaces.DEFAULT, "failedToReconnect", { uri: connection.mcUri }));
+
+            await this.removeConnection(connection);
+            return false;
+        }
+
+        if (MCEnvironment.envMatches(connection, newEnvData)) {
+            // it's the same instance, so we don't have to do anything
+            return true;
+        }
+        else {
+            Log.d("Microclimate instance changed on reconnect!");
+            await this.removeConnection(connection);
+
+            // will also add the new Connection to this ConnectionManager
+            const newConnection = await newConnectionCmd(MCUtil.getConnInfoFrom(connection.mcUri));
+            if (newConnection == null) {
+                // should never happen
+                Log.e("Failed to create new connection after verifyReconnect failure");
+                return false;
+            }
+
+            const msg = Translator.t(StringNamespaces.DEFAULT, "versionChanged",
+                { uri: connection.mcUri, oldVersion: connection.versionStr, newVersion: newConnection.versionStr }
+            );
+            vscode.window.showInformationMessage(msg);
+            return false;
+        }
     }
 
     private connectionExists(uri: vscode.Uri): boolean {
@@ -92,22 +152,9 @@ export default class ConnectionManager {
 
     public static async saveConnections(): Promise<void> {
         // We save IConnectionInfo objects since they are simpler and more readable than VSCode URIs.
-
-        // This is a bit tough to read - For each connection, convert it to a connInfo we can save nicely.
-        // If the convert fails, ignore it and log an error.
-        const connectionInfos: MCUtil.IConnectionInfo[] = ConnectionManager.instance.connections.reduce(
-            (result: MCUtil.IConnectionInfo[], conn: Connection): MCUtil.IConnectionInfo[] => {
-                const connInfo = MCUtil.getConnInfoFrom(conn.mcUri);
-                if (connInfo != null) {
-                    result.push(connInfo);
-                }
-                else {
-                    // shouldn't happen
-                    Log.e("Couldn't convert mcURI to connInfo!", conn.mcUri);
-                }
-                return result;
-            },
-        []);
+        // This will likely change with ICP support since we would then have to store protocol too.
+        const connectionInfos: MCUtil.IConnectionInfo[] = ConnectionManager.instance.connections
+            .map( (connection) => MCUtil.getConnInfoFrom(connection.mcUri));
 
         Log.i("Saving connections", connectionInfos);
         try {
@@ -120,17 +167,6 @@ export default class ConnectionManager {
             vscode.window.showErrorMessage(msg);
         }
     }
-
-    /*
-    public async getProjectByID(projectID: string): Promise<Project | undefined> {
-        for (const conn of this.connections) {
-            const proj: Project | undefined = await conn.getProjectByID(projectID);
-            if (proj != null) {
-                return proj;
-            }
-        }
-        return undefined;
-    }*/
 
     /**
      * Pass this a function to call whenever a connection is added, removed, or changed,

--- a/dev/src/microclimate/connection/MCEnvironment.ts
+++ b/dev/src/microclimate/connection/MCEnvironment.ts
@@ -1,0 +1,112 @@
+import { Uri } from "vscode";
+import * as request from "request-promise-native";
+import * as reqErrors from "request-promise-native/errors";
+
+import Log from "../../Logger";
+import Endpoints from "../../constants/Endpoints";
+import Translator from "../../constants/strings/translator";
+import StringNamespaces from "../../constants/strings/StringNamespaces";
+import Connection from "./Connection";
+
+const STRING_NS = StringNamespaces.CMD_NEW_CONNECTION;
+
+namespace MCEnvironment {
+
+    // From https://github.ibm.com/dev-ex/microclimate/blob/master/docker/portal/server.js#L229
+    export interface IMCEnvData {
+        devops_available: boolean;
+        editor_url: string;
+        microclimate_version: string;
+        running_on_icp: boolean;
+        socket_namespace?: string;
+        user_string?: string;
+        workspace_location: string;
+    }
+
+    export async function getEnvData(mcUri: Uri): Promise<IMCEnvData> {
+        const envUri: Uri = mcUri.with({ path: Endpoints.ENVIRONMENT });
+        const connectTimeout = 2500;
+
+        try {
+            const result = await request.get(envUri.toString(), { json: true, timeout: connectTimeout });
+            return result;
+        }
+        catch (err) {
+            Log.i(`Connection ENV Request fail - ${err}`);
+            if (err instanceof reqErrors.RequestError) {
+                throw new Error(Translator.t(STRING_NS, "connectFailed", { uri: mcUri }));
+            }
+            throw err;
+        }
+    }
+
+    // microclimate_version and workspace_location were both added in Microclimate 18.09
+    // Portal Restart API improvement was added in 18.11
+    export const REQUIRED_VERSION_STR: string = "18.12";     // non-nls
+    const REQUIRED_VERSION: number = 1812;
+    const INTERNAL_BUILD_RX: RegExp = /^\d{4}_M\d+_[EI]/;
+
+    /**
+     * Parses a version number out of the given env data. If it's a development build, returns Number.MAX_SAFE_INTEGER.
+     *
+     * **Throws an error** if the version is not supported.
+     */
+    export function getVersionNumber(envData: IMCEnvData): number {
+        const rawVersion = envData.microclimate_version;
+
+        if (rawVersion === "latest") {      // non-nls
+            // This means it's being hosted by an internal MC dev.
+            // There's nothing we can do here but assume they have all the features we need.
+            Log.i("Dev version of Microclimate");
+            return Number.MAX_SAFE_INTEGER;
+        }
+        else if (rawVersion.match(INTERNAL_BUILD_RX) != null) {
+            Log.i("Internal build of Microclimate");
+            return Number.MAX_SAFE_INTEGER;
+        }
+        else {
+            const versionNum = Number(rawVersion);
+            if (isNaN(versionNum)) {
+                Log.e("Couldn't convert provided version to Number, version is: " + rawVersion);
+                throw new Error(Translator.t(STRING_NS, "versionNotRecognized", { rawVersion: rawVersion, requiredVersion: REQUIRED_VERSION_STR}));
+            }
+            else if (versionNum < REQUIRED_VERSION) {
+                Log.e(`Microclimate version ${versionNum} is too old.`);
+                throw new Error(Translator.t(STRING_NS, "versionTooOld", { rawVersion: rawVersion, requiredVersion: REQUIRED_VERSION_STR}));
+            }
+            return versionNum;
+        }
+    }
+
+    export function getVersionAsString(versionNum: number): string {
+        if (versionNum === Number.MAX_SAFE_INTEGER) {
+            return "latest";
+        }
+        else {
+            const year = Math.floor(versionNum / 100);
+            const month = versionNum % 100;
+            return `${year}.${month}`;
+        }
+    }
+
+    /**
+     * @returns If the given Connection matches the given environment data for fields the tools are interested in.
+     */
+    export function envMatches(connection: Connection, envData: IMCEnvData): boolean {
+        let newVersionNumber;
+        try {
+            newVersionNumber = getVersionNumber(envData);
+        }
+        catch (err) {
+            Log.w(err);
+            return false;
+        }
+
+        return connection.version === newVersionNumber &&
+            connection.workspacePath.fsPath === envData.workspace_location;
+            // more to check once we support ICP
+            // envData.user_string
+    }
+}
+
+export default MCEnvironment;

--- a/dev/src/microclimate/logs/MCLogManager.ts
+++ b/dev/src/microclimate/logs/MCLogManager.ts
@@ -89,7 +89,7 @@ export default class MCLogManager {
      * When a connection dies, we have to stop updating its logs, but we should keep the logs visible.
      */
     public onConnectionDisconnect(): void {
-        Log.d(`LogManager for ${this.connection.mcUri} onDisconnect`);
+        // Log.d(`LogManager for ${this.connection.mcUri} onDisconnect`);
         this.appLogMap.forEach( (log) => {
             log.stopUpdating();
         });
@@ -104,7 +104,7 @@ export default class MCLogManager {
      * The easiest way to is destroy them and start from scratch.
      */
     public onConnectionReconnect(): void {
-        Log.d(`LogManager for ${this.connection.mcUri} onReconnect`);
+        // Log.d(`LogManager for ${this.connection.mcUri} onReconnect`);
         const oldAppLogs = new Map(this.appLogMap);
         this.appLogMap.clear();
         oldAppLogs.forEach( (log) => {


### PR DESCRIPTION
- On reconnect, verifies the environment is the same as before the disconnect.
    - If not, destroys that connection and forms a new one
- Move environment logic into its own file